### PR TITLE
Fix broken module imports

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -1,6 +1,11 @@
 import JLD
 import HDF5
 
+include("./mult.jl")
+include("./hals.jl")
+include("./anls.jl")
+using .MULT, .HALS, .ANLS
+
 ALGORITHMS = Dict(
     :mult => MULT,
     :hals => HALS,


### PR DESCRIPTION
Previous commit (bbef7978d1) broke imports. Julia 1.0 requires
including files before importing them. This is different than Julia 0.6.