### PR TITLE
Remove textwidth variable which causes conflict.

### DIFF
--- a/figures/plot_settings.jl
+++ b/figures/plot_settings.jl
@@ -1,5 +1,4 @@
 # PLOT SETTINGS
-textwidth = 469.75
 fontsize = 10
 ticksize = 8
 

--- a/figures/plot_settings.jl
+++ b/figures/plot_settings.jl
@@ -1,4 +1,5 @@
 # PLOT SETTINGS
+doc_textwidth = 469.75
 fontsize = 10
 ticksize = 8
 


### PR DESCRIPTION
When doing include("plot_settings.jl") I get an error that textwidth is
an already existing variable in Main, and can't be overwritten. Since
the variable is not being used in the plot_settings file (as far as I
can tell), I propose deleting it.