### PR TITLE
Fix Julia 1.0 compat

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -40,7 +40,8 @@ function sortperm(r::CNMF_results)
     # For each unit, compute the largest weight across
     # components.
     sum_over_lags = dropdims(sum(r.W, dims=1), dims=1)
-    max_component = argmax.(eachrow(sum_over_lags))
+    rows = [view(sum_over_lags, i, :) for i in axes(sum_over_lags, 1)]
+    max_component = argmax.(rows)
 
     # For each unit, compute the largest weight across
     # lags (within largest component).

--- a/src/visualize.jl
+++ b/src/visualize.jl
@@ -34,7 +34,7 @@ function plot_Ws(
         a.imshow(transpose(W[:, idx, k]), aspect="auto")
     end
 
-    if ~isnothing(trueW)
+    if !(trueW === nothing)
         fig2, ax2 = plt.subplots(1, num_components(r))
         for (k, a) in enumerate(ax2)
             a.imshow(transpose(trueW[:, idx, k]), aspect="auto")


### PR DESCRIPTION
A few functions used by visualize.jl and model.jl are supported in 1.1 but not 1.0.
Fix these for compatibility.

@degleris1 The other option is to bump REQUIRE to Julia 1.1. Do you have a preference?