### PR TITLE
New options for ANLS

### DIFF
--- a/src/anls.jl
+++ b/src/anls.jl
@@ -1,12 +1,10 @@
 module ANLS
 """
 Fit CNMF using Alternating Non-Negative Least Squares.
-Note: this requires having the NonNegLeastSquares source available 
-in a directory adjacent to the cmf.jl directory.
 """
 
 # Import 
-import NonNegLeastSquares
+using NonNegLeastSquares
 using LinearAlgebra
 include("./common.jl")
 
@@ -14,18 +12,22 @@ include("./common.jl")
 """
 Main update rule
 """
-function update!(data, W, H, meta; variant=nothing, kwargs...)
+function update!(data, W, H, meta; variant=:cache, block=false, kwargs...)
     if (meta == nothing)
         meta = ANLSmeta(data, W, H)
     end
 
     # W update
-    _update_W!(data, W, H)
+    _update_W!(data, W, H, variant=variant)
     meta.resids = compute_resids(data, W, H)
 
     # H update
-    _update_H!(W, H, meta)
-
+    if (block)
+        _block_update_H!(W, H, meta, variant=variant)
+    else
+        _update_H!(W, H, meta, variant=variant)
+    end
+    
     return norm(meta.resids) / meta.data_norm, meta
 end
 
@@ -46,27 +48,36 @@ mutable struct ANLSmeta
 end
 
 
-function _update_W!(data, W, H)
-    """
-    This is just a single NNLS solve using the unfolded H
-    matrix.
-    """
+"""
+This is just a single NNLS solve using the unfolded H matrix.
+"""
+function _update_W!(data, W, H; variant=:cache)
     L,N,K = size(W)
     H_unfold = shift_and_stack(H, L)
-    W_unfold = NonNegLeastSquares.nonneg_lsq(t(H_unfold), t(data), alg=:pivot)
+
+    if (variant == nothing)
+        W_unfold = nonneg_lsq(t(H_unfold), t(data), alg=:pivot)
+    else
+        W_unfold = nonneg_lsq(t(H_unfold), t(data), alg=:pivot, variant=variant)
+    end
+    
     W[:,:,:] = fold_W(t(W_unfold), L, N, K)
 end
-
-
 
 
 """
 Perform H update a single column at a time
 """
-function _update_H!(W, H, meta)
+function _update_H!(W, H, meta; variant=:cache, cols=nothing)
     N, T, K, L = unpack_dims(W, H)
+
+    if (cols == nothing)
+        inds = 1:T
+    else
+        inds = cols
+    end
     
-    for t in 1:T  
+    for t in inds  
         last = min(t+L-1, T)
         block_size = last - t + 1
         
@@ -79,7 +90,11 @@ function _update_H!(W, H, meta)
         b = vec(meta.resids[:, t:last])
         
         # Update one column of H
-        H[:,t] = NonNegLeastSquares.nonneg_lsq(unfolded_W, -b, alg=:pivot, variant=:comb)
+        if (variant == nothing)
+            H[:,t] = nonneg_lsq(unfolded_W, -b, alg=:pivot)
+        else
+            H[:,t] = nonneg_lsq(unfolded_W, -b, alg=:pivot, variant=variant)
+        end
         
         # Update residual
         for k = 1:K
@@ -87,47 +102,54 @@ function _update_H!(W, H, meta)
         end
     end
 end
-
 
 
 
 """
 Update several columns of H at once.
 """
-function _block_update_H!(data, W, H, meta)
+function _block_update_H!(W, H, meta; variant=variant)
     K, T = size(H)
     L, N, K = size(W)
 
-
-
     for l = 1:L
-        inds = 1:L:T-L
-        
-
-    end
-
-    
-    for t in 1:T
-        last = min(t+L-1, T)
-        block_size = last - t + 1
+        inds = 1:L:T-L+1
         
         # Remove contribution to residual
         for k = 1:K
-            meta.resids[:, t:last] -= H[k, t] * W[1:block_size, :, k]'
+            for t in inds
+                meta.resids[:, t:t+L-1] -= H[k, t] * W[:, :, k]'
+            end
+        end
+        
+        unfolded_W = _unfold_W(W)
+
+        B = zeros(N*L, length(inds))
+        for i in 1:length(inds)
+            t = inds[i]
+            B[:, i] = vec(meta.resids[:, t:t+L-1])
         end
 
-        unfolded_W = _unfold_W(W)[1:block_size*N, :]
-        b = vec(meta.resids[:, t:last])
+        # Update block of H
+        if (variant == nothing)
+            H[:, inds] = NonNegLeastSquares.nonneg_lsq(unfolded_W, -B,
+                                                   alg=:pivot)
+        else
+            H[:, inds] = NonNegLeastSquares.nonneg_lsq(unfolded_W, -B,
+                                                   alg=:pivot, variant=variant)
+        end
         
-        # Update one column of H
-        H[:,t] = NonNegLeastSquares.nonneg_lsq(unfolded_W, -b, alg=:pivot)
-
         # Update residual
         for k = 1:K
-            meta.resids[:, t:last] += H[k, t] * W[1:block_size, :, k]'
+            for t in inds
+                meta.resids[:, t:t+L-1] += H[k, t] * W[:, :, k]'
+            end
         end
     end
+
+    _update_H!(W, H, meta; variant=variant, cols=T-L+2:T)
 end
+
 
 function _unfold_W(W)
     L, N, K = size(W)

--- a/src/common.jl
+++ b/src/common.jl
@@ -67,3 +67,11 @@ function shift_and_stack(H, L)
 
     return H_stacked
 end
+
+
+function unpack_dims(W, H)
+    L, N, K = size(W)
+    T = size(H, 2)
+
+    return N, T, K, L
+end

--- a/src/model.jl
+++ b/src/model.jl
@@ -66,8 +66,8 @@ function fit_cnmf(data; L=10, K=5, alg=:mult,
 
     # Initialize
     W, H = init_rand(data, L, K)
-    W = get(kwargs, :initW, W)
-    H = get(kwargs, :initH, H)
+    W = deepcopy(get(kwargs, :initW, W))
+    H = deepcopy(get(kwargs, :initH, H))
     
     meta = nothing
     
@@ -88,14 +88,9 @@ function fit_cnmf(data; L=10, K=5, alg=:mult,
              l2_H == 0 &&
              l1_W == 0 &&
              l2_W == 0) || error("Regularization not supported with ANLS")
-             loss, meta = ALGORITHMS[alg].update!(data, W, H, meta;
-                                             kwargs...)
-        else
-            loss, meta = ALGORITHMS[alg].update!(data, W, H, meta;
-                                                 l1_H=l1_H, l2_H=l2_H,
-                                                 l1_W=l1_W, l2_W=l2_W,
-                                                 kwargs...)
         end
+        
+        loss, meta = ALGORITHMS[alg].update!(data, W, H, meta; kwargs...)
         dur = time() - t0
         
         # Record time and loss

--- a/tests/test.jl
+++ b/tests/test.jl
@@ -1,22 +1,20 @@
-using Plots
+using PyPlot; plt = PyPlot
 using Revise
 using CMF: fit_cnmf, synthetic_sequences, init_rand
 
 K, L = 3, 10
-data, W, H = synthetic_sequences(N=100, T=250, K=K, L=L)
+data, W, H = synthetic_sequences(N=250, T=2500, K=K, L=L)
 initW, initH = init_rand(data, L, K)
 
-plot(xlabel="Time", ylabel="Loss")
 
 alg_results = Dict()
 settings = [
     [:hals, Dict(), "HALS"],
     #[:mult, Dict(), "MULT"],
-    [:anls, Dict(), "ANLS"],
-    [:anls, Dict(:variant => :cache), "Cached ANLS"],
-    [:anls, Dict(:variant => :pivot), "Pivot ANLS"],
+    [:anls, Dict(), "ANLS"]
 ]
 
+plt.figure()
 for (alg, kwargs, label) in settings
     results = fit_cnmf(data; L=L, K=K,
                        alg=alg, max_itr=Inf, max_time=5,
@@ -24,12 +22,12 @@ for (alg, kwargs, label) in settings
                        kwargs...
                        )
 
-    plot!(results.time_hist, results.loss_hist, label=label)
-    scatter!(results.time_hist, results.loss_hist, markersize=1, label="")
-
+    plt.plot(results.time_hist, results.loss_hist, label=label, marker=".")
     alg_results[alg] = results
 end
+plt.legend()
+plt.xlabel("Time (seconds)")
+plt.ylabel("Loss")
 
-savefig("cnmf_test.png")
-gui()
+plt.savefig("cnmf_test.png")
 ;

--- a/tests/test.jl
+++ b/tests/test.jl
@@ -1,19 +1,26 @@
 using Plots
-using CMF: fit_cnmf, synthetic_sequences
+using Revise
+using CMF: fit_cnmf, synthetic_sequences, init_rand
 
-
-data, W, H = synthetic_sequences(N=500, T=2000)
+K, L = 3, 10
+data, W, H = synthetic_sequences(N=100, T=250, K=K, L=L)
+initW, initH = init_rand(data, L, K)
 
 plot(xlabel="Time", ylabel="Loss")
 
 alg_results = Dict()
-for (alg, kwargs, label) in [
+settings = [
     [:hals, Dict(), "HALS"],
-    [:mult, Dict(), "MULT"],
-    #[:anls, Dict(), "ANLS"],
+    #[:mult, Dict(), "MULT"],
+    [:anls, Dict(), "ANLS"],
+    [:anls, Dict(:variant => :cache), "Cached ANLS"],
+    [:anls, Dict(:variant => :pivot), "Pivot ANLS"],
 ]
-    results = fit_cnmf(data; L=20, K=3,
-                       alg=alg, max_itr=Inf, max_time=30,
+
+for (alg, kwargs, label) in settings
+    results = fit_cnmf(data; L=L, K=K,
+                       alg=alg, max_itr=Inf, max_time=5,
+                       initW=initW, initH=initH,
                        kwargs...
                        )
 
@@ -23,6 +30,6 @@ for (alg, kwargs, label) in [
     alg_results[alg] = results
 end
 
-savefig("cnmf_alg_comparison.png")
+savefig("cnmf_test.png")
 gui()
 ;


### PR DESCRIPTION
The ANLS algorithm now supports:
  - Different variants of the pivot algorithm. The default is `cache`, which enjoys performance boosts on large datasets.
  - A block update option. This is currently slow.

Additional changes:
  - Model now deep copies the initialization, to avoid overwriting it.
  - `test.jl` now uses PyPlot, since it has more reliable behavior.
  - A helper function `unpack_dims` returns `N, T, K, L` if you pass `W` and `H`.
  - Some small aesthetic changes.