### PR TITLE
Removed old imports

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,9 +2,6 @@ julia 1.0
 JLD
 NonNegLeastSquares
 HDF5
-ImageFiltering
-DSP
 PyPlot
-Distributions
 Combinatorics
 Random

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,4 +4,3 @@ NonNegLeastSquares
 HDF5
 PyPlot
 Combinatorics
-Random

--- a/src/CMF.jl
+++ b/src/CMF.jl
@@ -9,7 +9,6 @@ using HDF5
 import Base: sortperm
 import Random
 
-const ds = Distributions
 
 # Need to load model.jl dependencies
 # before including model.jl

--- a/src/CMF.jl
+++ b/src/CMF.jl
@@ -2,14 +2,10 @@ module CMF
 
 export fit_cnmf
 
-# Dependendies.
+# Dependencies.
 import PyPlot; const plt = PyPlot
 using LinearAlgebra
 using HDF5
-using ImageFiltering
-import DSP
-import WAV
-import Distributions
 import Base: sortperm
 import Random
 


### PR DESCRIPTION
Removed imports we no longer use in `CMF.jl`: `WAV`, `Distributions`, `DSP`, and `ImageFiltering`.