### PR TITLE
Use ReverseDiff for calculating gradients

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -57,11 +57,23 @@ git-tree-sha1 = "140cc833258df8e5aafabdb068875ac0c256be23"
 uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 version = "1.0.0"
 
+[[CommonSubexpressions]]
+deps = ["MacroTools", "Test"]
+git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+version = "0.3.0"
+
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
 git-tree-sha1 = "b0b7e8a0d054fada22b64095b46469627a138943"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "2.2.1"
+
+[[CompilerSupportLibraries_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "7c4f882c41faa72118841185afc58a2eb00ef612"
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "0.3.3+0"
 
 [[Conda]]
 deps = ["JSON", "VersionParsing"]
@@ -76,6 +88,18 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 [[DelimitedFiles]]
 deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[DiffResults]]
+deps = ["StaticArrays"]
+git-tree-sha1 = "da24935df8e0c6cf28de340b958f6aac88eaa0cc"
+uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+version = "1.0.2"
+
+[[DiffRules]]
+deps = ["NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "eb0c34204c8410888844ada5359ac8b96292cfd1"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "1.0.1"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
@@ -104,6 +128,17 @@ deps = ["Statistics"]
 git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.8.4"
+
+[[ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "NaNMath", "Random", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "1d090099fb82223abc48f7ce176d3f7696ede36d"
+uuid = "f6369f11-7733-5829-9624-2563aa707210"
+version = "0.10.12"
+
+[[FunctionWrappers]]
+git-tree-sha1 = "e4813d187be8c7b993cb7f85cbf2b7bfbaadc694"
+uuid = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
+version = "1.1.1"
 
 [[HDF5]]
 deps = ["Blosc", "HDF5_jll", "Libdl", "Mmap", "Random"]
@@ -188,6 +223,17 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[NaNMath]]
+git-tree-sha1 = "c84c576296d0e2fbb3fc134d3e09086b3ea617cd"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "0.3.4"
+
+[[OpenSpecFun_jll]]
+deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
+git-tree-sha1 = "d51c416559217d974a1113522d5919235ae67a87"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.3+3"
+
 [[OrderedCollections]]
 git-tree-sha1 = "16c08bf5dba06609fe45e30860092d6fa41fde7b"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
@@ -221,9 +267,9 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[PyCall]]
 deps = ["Conda", "Dates", "Libdl", "LinearAlgebra", "MacroTools", "Serialization", "VersionParsing"]
-git-tree-sha1 = "3a3fdb9000d35958c9ba2323ca7c4958901f115d"
+git-tree-sha1 = "b4e471a2b1739dba687d22d3293aa16bc5f3925b"
 uuid = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
-version = "1.91.4"
+version = "1.92.0"
 
 [[PyPlot]]
 deps = ["Colors", "LaTeXStrings", "PyCall", "Sockets", "Test", "VersionParsing"]
@@ -250,6 +296,12 @@ git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "0.2.0"
 
+[[ReverseDiff]]
+deps = ["DiffResults", "DiffRules", "ForwardDiff", "FunctionWrappers", "LinearAlgebra", "MacroTools", "NaNMath", "Random", "SpecialFunctions", "StaticArrays", "Statistics"]
+git-tree-sha1 = "97c6f7dc9ef6ca1d5bd3aa0072d804281af5072d"
+uuid = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+version = "1.4.3"
+
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
@@ -271,6 +323,18 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 [[SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SpecialFunctions]]
+deps = ["OpenSpecFun_jll"]
+git-tree-sha1 = "d8d8b8a9f4119829410ecd706da4cc8594a1e020"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "0.10.3"
+
+[[StaticArrays]]
+deps = ["LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "016d1e1a00fabc556473b07161da3d39726ded35"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "0.12.4"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 
 [compat]
 julia = "≥ 1.3.0"

--- a/src/CMF.jl
+++ b/src/CMF.jl
@@ -16,6 +16,7 @@ import HDF5
 import JLD
 import MLJModelInterface
 import MLJModelInterface: @mlj_model
+import ReverseDiff
 
 # Constants
 const Tensor{T} = Array{T, 3}

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -145,6 +145,10 @@ end
 ########
 ####    CONSTRAINTS
 ########
+struct NoConstraint <: AbstractConstraint end
+function projection!(c::NoConstraint, x)
+    return
+end
 
 
 """ x_i >= 0 for all i """

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -147,7 +147,7 @@ end
 ########
 struct NoConstraint <: AbstractConstraint end
 function projection!(c::NoConstraint, x)
-    return
+    return x
 end
 
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -15,14 +15,14 @@ Must implement:
 abstract type AbstractCFAlgorithm end
 
 
-function tensor_conv(W::Tensor, H::Matrix)
+function tensor_conv(W::AbstractArray, H::AbstractArray)
     K, N, L = size(W)
     est = zeros(N, size(H, 2))
     return tensor_conv!(est, W, H)
 end
 
 
-function tensor_conv!(est, W::Tensor, H::Matrix)
+function tensor_conv!(est, W::AbstractArray, H::AbstractArray)
     K, N, L = size(W)
     T = size(H, 2)
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -4,8 +4,8 @@
     loss::AbstractLoss = SquareLoss()
     W_penalizers::Vector{AbstractPenalty} = AbstractPenalty[]
     H_penalizers::Vector{AbstractPenalty} = AbstractPenalty[]
-    W_constraints::Vector{AbstractConstraint} = AbstractConstraint[]
-    H_constraints::Vector{AbstractConstraint} = AbstractConstraint[]
+    W_constraint::AbstractConstraint = NoConstraint()
+    H_constraint::AbstractConstraint = NoConstraint()
     algorithm::Symbol = :pgd::(_ in (:pgd,))
     max_iters::Int = 100::(_ > 0)
     max_time::Float64 = Inf::(_ > 0)


### PR DESCRIPTION
- Replace manual gradient calculations with calls to ReverseDiff inside PGD.
- Add ReverseDiff as dependency.
- Change to only accept a single constraint on W and H, since accepting multiple constraints would
  require an alternating projections routine. We might add this later.
- Change TensorConv and related funcs to take AbstractArrays. This is required for ReverseDiff to be
  able to differentiate through them. In the future, we should do performance benchmarks to check if
this affects anything.

PERFORMANCE NOTE: Currently we are not using the gradient_tape function of reverse diff, which means
that the loss function is re-traced every time we evaluate the gradient. We will revisit this in the
future to improve performance.